### PR TITLE
harden: sanitize child_process call in git.js...

### DIFF
--- a/src/git.js
+++ b/src/git.js
@@ -65,7 +65,7 @@ export const init = (repoSlugAndBranch) => {
 			execFile(
 				"git",
 				args,
-				{ shell: false, env: { ...process.env, GIT_LFS_SKIP_SMUDGE: "1" } },
+				{ env: { ...process.env, GIT_LFS_SKIP_SMUDGE: "1" }, shell: false },
 				function (error, stdout) {
 					if (error) {
 						log.info(`OUTPUT ERROR: ${error}`);
@@ -78,7 +78,10 @@ export const init = (repoSlugAndBranch) => {
 	};
 
 	const hasChanges = async () => {
-		const statusOutput = await execCmd(["git", "status", "--porcelain"], getRepoPath());
+		const statusOutput = await execCmd(
+			["git", "status", "--porcelain"],
+			getRepoPath()
+		);
 		return porcelainParse(statusOutput).length !== 0;
 	};
 

--- a/src/git.js
+++ b/src/git.js
@@ -1,4 +1,4 @@
-import { exec } from "child_process";
+import { execFile } from "child_process";
 
 import { parse as porcelainParse } from "@putout/git-status-porcelain";
 
@@ -20,7 +20,7 @@ const interpolateCommitMessage = (message, data) => {
 		if (key === "COMMIT_MESSAGE") {
 			return;
 		}
-		newMessage = newMessage.replace(new RegExp(`%${key}%`, "g"), data[key]);
+		newMessage = newMessage.split(`%${key}%`).join(data[key]);
 	});
 	return newMessage;
 };
@@ -29,13 +29,16 @@ export const init = (repoSlugAndBranch) => {
 	const { getRepoPath, getRepoSlug, getRepoBranch } =
 		utils.init(repoSlugAndBranch);
 
-	function execCmd(command, workingDir) {
-		log.info(`EXEC: "${command}" IN "${workingDir || "./"}"`);
+	function execCmd(args, workingDir) {
+		const [cmd, ...cmdArgs] = args;
+		log.info(`EXEC: "${args.join(" ")}" IN "${workingDir || "./"}"`);
 		return new Promise((resolve, reject) => {
-			exec(
-				command,
+			execFile(
+				cmd,
+				cmdArgs,
 				{
 					cwd: workingDir,
+					shell: false,
 				},
 				function (error, stdout) {
 					if (error) {
@@ -49,19 +52,33 @@ export const init = (repoSlugAndBranch) => {
 	}
 
 	const clone = async () => {
-		const command = [
-			"GIT_LFS_SKIP_SMUDGE=1",
-			"git clone",
-			"--depth 1",
-			getRepoBranch() === undefined ? false : ` -b ${getRepoBranch()}`,
+		const args = [
+			"clone",
+			"--depth",
+			"1",
+			...(getRepoBranch() !== undefined ? ["-b", getRepoBranch()] : []),
 			`https://${GITHUB_TOKEN}@${GITHUB_SERVER}/${getRepoSlug()}.git`,
 			getRepoPath(),
 		];
-		return execCmd(command.filter(Boolean).join(" "));
+		log.info(`EXEC: "git ${args.join(" ")}" IN "./"`);
+		return new Promise((resolve, reject) => {
+			execFile(
+				"git",
+				args,
+				{ shell: false, env: { ...process.env, GIT_LFS_SKIP_SMUDGE: "1" } },
+				function (error, stdout) {
+					if (error) {
+						log.info(`OUTPUT ERROR: ${error}`);
+					}
+					log.info(`OUTPUT STDOUT: ${stdout ? `"${stdout}"` : "none"}`);
+					error ? reject(error) : resolve(stdout.trim());
+				}
+			);
+		});
 	};
 
 	const hasChanges = async () => {
-		const statusOutput = await execCmd(`git status --porcelain`, getRepoPath());
+		const statusOutput = await execCmd(["git", "status", "--porcelain"], getRepoPath());
 		return porcelainParse(statusOutput).length !== 0;
 	};
 
@@ -78,12 +95,12 @@ export const init = (repoSlugAndBranch) => {
 		});
 		if (!DRY_RUN) {
 			const commands = [
-				`git config --local user.name "${GIT_USERNAME}"`,
-				`git config --local user.email "${GIT_EMAIL}"`,
-				`git add --all`,
-				`git status`,
-				`git commit --message "${commitMessage}"`,
-				`git push`,
+				["git", "config", "--local", "user.name", GIT_USERNAME],
+				["git", "config", "--local", "user.email", GIT_EMAIL],
+				["git", "add", "--all"],
+				["git", "status"],
+				["git", "commit", "--message", commitMessage],
+				["git", "push"],
 			];
 			try {
 				for (const cmd of commands) {


### PR DESCRIPTION
## Summary
Harden input handling in `src/git.js` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | javascript.lang.security.detect-child-process.detect-child-process |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `javascript.lang.security.detect-child-process.detect-child-process` |
| **File** | `src/git.js:36` |
| **Assessment** | Defensive hardening |

**Description**: Detected calls to child_process from a function argument `command`. This could lead to a command injection if the input is user controllable. Try to avoid calls to child_process, and if it is needed ensure user input is correctly sanitized or sandboxed. 

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `src/git.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
